### PR TITLE
Correct AdMob Docs; Add GoogleAds Docs

### DIFF
--- a/docs/plugins/adMob/index.md
+++ b/docs/plugins/adMob/index.md
@@ -4,17 +4,17 @@ title: ngCordova - Document and Examples - by the Ionic Framework Team
 
 plugin-name: $cordovaAdMob
 source: https://github.com/driftyco/ng-cordova/blob/master/src/plugins/adMob.js
-official-docs: https://github.com/floatinghotpot/cordova-admob-pro
+official-docs: https://github.com/floatinghotpot/cordova-plugin-admob
 icon-apple: true
 icon-android: true
 icon-windows: false
 ---
 
-The [AdMob](https://github.com/floatinghotpot/cordova-admob-pro) plugin presents AdMob Ads in Mobile App/Games natively from JavaScript.
+The [AdMob](https://github.com/floatinghotpot/cordova-plugin-admob) plugin presents AdMob Ads in Mobile App/Games natively from JavaScript.
 
 
 ```bash
-cordova plugin add com.google.cordova.admob
+cordova plugin add com.rjfun.cordova.plugin.admob
 ```
 
 

--- a/docs/plugins/googleAds/index.md
+++ b/docs/plugins/googleAds/index.md
@@ -1,0 +1,27 @@
+---
+layout: docs-plugins
+title: ngCordova - Document and Examples - by the Ionic Framework Team
+
+plugin-name: $cordovaGoogleAds
+source: https://github.com/driftyco/ng-cordova/blob/master/src/plugins/googleAds.js
+official-docs: https://github.com/floatinghotpot/cordova-admob-pro
+icon-apple: true
+icon-android: true
+icon-windows: false
+---
+
+The [GoogleAds](https://github.com/floatinghotpot/cordova-admob-pro) plugin presents GoogleAds Ads in Mobile App/Games natively from JavaScript.
+
+
+```bash
+cordova plugin add com.google.cordova.admob
+```
+
+
+```javascript
+
+module.controller('GoogleAdsCtrl', function($scope, $cordovaGoogleAds) {
+    // GoogleAds implementation here
+    // coming soon...
+});
+```


### PR DESCRIPTION
The AdMob docs were pointing to an updated plugin, whose API has changed.  This PR points the docs to the correct plugin, and introduces Google Ads documentation (the code already exists, it is just undocumented).
